### PR TITLE
🐛 fix typings-entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
+  "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/process-engine/consumer_api_contracts.git"


### PR DESCRIPTION
## What did you change?

The typings were not being exported before, because the `typings`-entry in the package.json was missing. This branch fixes that.

## How can others test the changes?

When using the typings of this package, typescript should now actually give you warnings instead of ignoring everything

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
