### PR TITLE
rename startProcess to startProcessInstance

### DIFF
--- a/src/iconsumer_api_service.ts
+++ b/src/iconsumer_api_service.ts
@@ -16,16 +16,16 @@ export interface IConsumerApiService {
   // Process models
   getProcessModels(context: ConsumerContext): Promise<ProcessModelList>;
   getProcessModelByKey(context: ConsumerContext, processModelKey: string): Promise<ProcessModel>;
-  startProcess(context: ConsumerContext,
-               processModelKey: string,
-               startEventKey: string,
-               payload: ProcessStartRequestPayload,
-               returnOn: ProcessStartReturnOnOptions): Promise<ProcessStartResponsePayload>;
-  startProcessAndAwaitEndEvent(context: ConsumerContext,
-                               processModelKey: string,
-                               startEventKey: string,
-                               endEventKey: string,
-                               payload: ProcessStartRequestPayload): Promise<ProcessStartResponsePayload>;
+  startProcessInstance(context: ConsumerContext,
+                       processModelKey: string,
+                       startEventKey: string,
+                       payload: ProcessStartRequestPayload,
+                       returnOnOption: ProcessStartReturnOnOptions): Promise<ProcessStartResponsePayload>;
+  startProcessInstanceAndAwaitEndEvent(context: ConsumerContext,
+                                       processModelKey: string,
+                                       startEventKey: string,
+                                       endEventKey: string,
+                                       payload: ProcessStartRequestPayload): Promise<ProcessStartResponsePayload>;
   // Events
   getEventsForProcessModel(context: ConsumerContext, processModelKey: string): Promise<EventList>;
   getEventsForCorrelation(context: ConsumerContext, correlationId: string): Promise<EventList>;


### PR DESCRIPTION
## What did you change?

- Rename `startProcess` to `startProcessInstance`
- Rename `startProcessAndAwaitEndEvent` to `startProcessInstanceAndAwaitEndEvent`

The method signatures now match the .NET Consumer API definitions.

## How can others test the changes?

This is a cosmetic change, so everything should work as before.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
