### PR TITLE
Feature/merge process start functions

### DIFF
--- a/src/data_models/process_model/start_callback_type.ts
+++ b/src/data_models/process_model/start_callback_type.ts
@@ -1,4 +1,5 @@
 export enum StartCallbackType {
     CallbackOnProcessInstanceCreated = 1,
+    CallbackOnProcessInstanceFinished = 2,
     CallbackOnEndEventReached = 3,
 }

--- a/src/iconsumer_api_service.ts
+++ b/src/iconsumer_api_service.ts
@@ -21,12 +21,8 @@ export interface IConsumerApiService {
                        processModelKey: string,
                        startEventKey: string,
                        payload: ProcessStartRequestPayload,
-                       startCallbackType: StartCallbackType): Promise<ProcessStartResponsePayload>;
-  startProcessInstanceAndAwaitEndEvent(context: ConsumerContext,
-                                       processModelKey: string,
-                                       startEventKey: string,
-                                       endEventKey: string,
-                                       payload: ProcessStartRequestPayload): Promise<ProcessStartResponsePayload>;
+                       startCallbackType: StartCallbackType,
+                       endEventKey?: string): Promise<ProcessStartResponsePayload>;
   getProcessResultForCorrelation(context: ConsumerContext, correlationId: string, processModelKey: string): Promise<ICorrelationResult>;
   // Events
   getEventsForProcessModel(context: ConsumerContext, processModelKey: string): Promise<EventList>;


### PR DESCRIPTION
Closes #16 

## What did you change?

- Add a new value for `startCallbackValue`: `CallbackOnProcessInstanceFinished`
  - All three callback types can now be addressed by using this enumeration
- Merge the two functions for starting process instances

## How can others test the changes?

- Try using the `startProcessInstanceAndAwaitEndEvent` method and see that it is gone
- Use the `startProcessInstance` function for what was previously done with `startProcessInstanceAndAwaitEndEvent` and see that it works

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
