### PR TITLE
Feature/refactor correlation result

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_contracts",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/correlation_result.ts
+++ b/src/correlation_result.ts
@@ -1,4 +1,4 @@
-export class ICorrelationResult {
+export class CorrelationResult {
   public correlationId: string;
   public endEventId: string;
   public tokenPayload: string;

--- a/src/iconsumer_api_service.ts
+++ b/src/iconsumer_api_service.ts
@@ -9,9 +9,9 @@ import {
   UserTaskList,
   UserTaskResult,
 } from './data_models/index';
-import {ICorrelationResult} from './icorrelation_result';
 
-import {ConsumerContext} from './index';
+import {ConsumerContext} from './consumer_context';
+import {CorrelationResult} from './correlation_result';
 
 export interface IConsumerApiService {
   // Process models
@@ -23,7 +23,7 @@ export interface IConsumerApiService {
                        payload: ProcessStartRequestPayload,
                        startCallbackType: StartCallbackType,
                        endEventKey?: string): Promise<ProcessStartResponsePayload>;
-  getProcessResultForCorrelation(context: ConsumerContext, correlationId: string, processModelKey: string): Promise<Array<ICorrelationResult>>;
+  getProcessResultForCorrelation(context: ConsumerContext, correlationId: string, processModelKey: string): Promise<Array<CorrelationResult>>;
   // Events
   getEventsForProcessModel(context: ConsumerContext, processModelKey: string): Promise<EventList>;
   getEventsForCorrelation(context: ConsumerContext, correlationId: string): Promise<EventList>;

--- a/src/iconsumer_api_service.ts
+++ b/src/iconsumer_api_service.ts
@@ -23,7 +23,7 @@ export interface IConsumerApiService {
                        payload: ProcessStartRequestPayload,
                        startCallbackType: StartCallbackType,
                        endEventKey?: string): Promise<ProcessStartResponsePayload>;
-  getProcessResultForCorrelation(context: ConsumerContext, correlationId: string, processModelKey: string): Promise<ICorrelationResult>;
+  getProcessResultForCorrelation(context: ConsumerContext, correlationId: string, processModelKey: string): Promise<Array<ICorrelationResult>>;
   // Events
   getEventsForProcessModel(context: ConsumerContext, processModelKey: string): Promise<EventList>;
   getEventsForCorrelation(context: ConsumerContext, correlationId: string): Promise<EventList>;

--- a/src/icorrelation_result.ts
+++ b/src/icorrelation_result.ts
@@ -1,3 +1,5 @@
-export interface ICorrelationResult {
-  [field: string]: any;
+export class ICorrelationResult {
+  public correlationId: string;
+  public endEventId: string;
+  public tokenPayload: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export * from './messagebus_api/index';
 
 export * from './consumer_context';
 export * from './consumer_request';
+export * from './correlation_result';
 export * from './iconsumer_api_accessor';
 export * from './iconsumer_api_service';
-export * from './icorrelation_result';
 export * from './rest_settings';


### PR DESCRIPTION
Closes #26 

## What did you change?

Refactors the correlation result, so that it contains additional information about the correlation and the end event that was reached.

Also changes the `getProcessResultForCorrelation` return value into `Array<CorrelationResult>`, so that process instances with multiple end events are now supported.

## How can others test the changes?

Run the integrationtests.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
