### PR TITLE
♻️ Refactor socket io handling

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_contracts",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/process-engine/consumer_api_contracts#readme",
   "dependencies": {
     "@essential-projects/http_contracts": "~2.3.0",
-    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling"
+    "@essential-projects/iam_contracts": "~3.4.0"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "^1.1.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/process-engine/consumer_api_contracts#readme",
   "dependencies": {
+    "@essential-projects/event_aggregator_contracts": "~4.0.0",
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/iam_contracts": "~3.4.0"
   },

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/process-engine/consumer_api_contracts#readme",
   "dependencies": {
     "@essential-projects/http_contracts": "~2.3.0",
-    "@essential-projects/iam_contracts": "~3.3.0"
+    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "^1.1.3",

--- a/typescript/src/apis/imanual_task_consumer_api.ts
+++ b/typescript/src/apis/imanual_task_consumer_api.ts
@@ -103,7 +103,7 @@ export interface IManualTaskConsumerApi {
    *                   information about the ManualTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Subscription;
+  onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Subscription | Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask is finished.
@@ -116,7 +116,7 @@ export interface IManualTaskConsumerApi {
    *                   information about the ManualTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Subscription;
+  onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Subscription | Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask for the given identity is reached.
@@ -129,7 +129,10 @@ export interface IManualTaskConsumerApi {
    *                 information about the ManualTask.
    * @returns        The Subscription created by the EventAggregator.
    */
-  onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Subscription;
+  onManualTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+  ): Subscription | Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask for the given identity is finished.
@@ -142,5 +145,8 @@ export interface IManualTaskConsumerApi {
    *                   information about the ManualTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Subscription;
+  onManualTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+  ): Subscription | Promise<Subscription>;
 }

--- a/typescript/src/apis/imanual_task_consumer_api.ts
+++ b/typescript/src/apis/imanual_task_consumer_api.ts
@@ -1,3 +1,4 @@
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {ManualTaskList} from '../data_models/manual_task/index';
@@ -70,63 +71,76 @@ export interface IManualTaskConsumerApi {
    * within a Correlation.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param processInstanceId The ID of the ProcessInstance for which to finish a
-   *                       ManualTask.
-   * @param correlationId  The ID of the correlation for which to finish a ManualTask.
+   * @param identity             The requesting users identity.
+   * @param processInstanceId    The ID of the ProcessInstance for which to
+   *                             finish a ManualTask.
+   * @param correlationId        The ID of the correlation for which to finish
+   *                             a ManualTask.
    * @param manualTaskInstanceId The instance ID of a ManualTask to finish.
-   * @param manualTaskResult Optional: Contains a set of results with which to
-   *                       finish the ManualTask.
-   * @returns              A Promise, which resolves without content, or rejects an error, in case the request failed.
-   *                       This can happen, if the ManualTask, ProcessModel or correlation were not found,
-   *                       or the user is not authorized to see either.
+   * @param manualTaskResult     Optional: Contains a set of results with which
+   *                             to finish the ManualTask.
+   * @returns                    A Promise, which resolves without content, or
+   *                             rejects an error, in case the request failed.
+   *                             This can happen, if the ManualTask, ProcessModel
+   *                             or correlation were not found, or the user is
+   *                             not authorized to see either.
    */
-  finishManualTask(identity: IIdentity,
-                   processInstanceId: string,
-                   correlationId: string,
-                   manualTaskInstanceId: string): Promise<void>;
+  finishManualTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    manualTaskInstanceId: string,
+  ): Promise<void>;
 
   /**
-   * Executes a callback when a manual task is reached.
+   * Executes a callback when a ManualTask is reached.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a manual task
-   *                       is reached. The message passed to the callback
-   *                       contains further information about the manual task.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a ManualTask is
+   *                   reached.
+   *                   The message passed to the callback contains further
+   *                   information about the ManualTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void;
+  onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Subscription;
 
   /**
-   * Executes a callback when a manual task is finished.
+   * Executes a callback when a ManualTask is finished.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a manual task
-   *                       is finished. The message passed to the callback
-   *                       contains further information about the manual task.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a ManualTask is
+   *                   finished.
+   *                   The message passed to the callback contains further
+   *                   information about the ManualTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void;
+  onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Subscription;
 
   /**
    * Executes a callback when a ManualTask for the given identity is reached.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a ManualTask
-   *                       is reached. The message passed to the callback
-   *                       contains further information about the ManualTask.
+   * @param identity The requesting users identity.
+   * @param callback The callback that will be executed when a ManualTask is
+   *                 reached.
+   *                 The message passed to the callback contains further
+   *                 information about the ManualTask.
+   * @returns        The Subscription created by the EventAggregator.
    */
-  onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void;
+  onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Subscription;
 
   /**
    * Executes a callback when a ManualTask for the given identity is finished.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a ManualTask
-   *                       is finished. The message passed to the callback
-   *                       contains further information about the ManualTask.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a ManualTask is
+   *                   finished.
+   *                   The message passed to the callback contains further
+   *                   information about the ManualTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void;
+  onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Subscription;
 }

--- a/typescript/src/apis/imanual_task_consumer_api.ts
+++ b/typescript/src/apis/imanual_task_consumer_api.ts
@@ -96,57 +96,79 @@ export interface IManualTaskConsumerApi {
    * Executes a callback when a ManualTask is reached.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a ManualTask is
-   *                   reached.
-   *                   The message passed to the callback contains further
-   *                   information about the ManualTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a ManualTask
+   *                        is reached.
+   *                        The message passed to the callback contains further
+   *                        information about the ManualTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription>;
+  onManualTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask is finished.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a ManualTask is
-   *                   finished.
-   *                   The message passed to the callback contains further
-   *                   information about the ManualTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a ManualTask
+   *                        is finished.
+   *                        The message passed to the callback contains further
+   *                        information about the ManualTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription>;
+  onManualTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask for the given identity is reached.
    *
    * @async
-   * @param identity The requesting users identity.
-   * @param callback The callback that will be executed when a ManualTask is
-   *                 reached.
-   *                 The message passed to the callback contains further
-   *                 information about the ManualTask.
-   * @returns        The Subscription created by the EventAggregator.
+   * @param identity        The requesting users identity.
+   * @param callback        The callback that will be executed when a ManualTask
+   *                        is reached.
+   *                        The message passed to the callback contains further
+   *                        information about the ManualTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
   onManualTaskForIdentityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce?: boolean,
   ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask for the given identity is finished.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a ManualTask is
-   *                   finished.
-   *                   The message passed to the callback contains further
-   *                   information about the ManualTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a ManualTask
+   *                        is finished.
+   *                        The message passed to the callback contains further
+   *                        information about the ManualTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
   onManualTaskForIdentityFinished(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce?: boolean,
   ): Promise<Subscription>;
 }

--- a/typescript/src/apis/imanual_task_consumer_api.ts
+++ b/typescript/src/apis/imanual_task_consumer_api.ts
@@ -103,7 +103,7 @@ export interface IManualTaskConsumerApi {
    *                   information about the ManualTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Subscription | Promise<Subscription>;
+  onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask is finished.
@@ -116,7 +116,7 @@ export interface IManualTaskConsumerApi {
    *                   information about the ManualTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Subscription | Promise<Subscription>;
+  onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask for the given identity is reached.
@@ -132,7 +132,7 @@ export interface IManualTaskConsumerApi {
   onManualTaskForIdentityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
-  ): Subscription | Promise<Subscription>;
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask for the given identity is finished.
@@ -148,5 +148,5 @@ export interface IManualTaskConsumerApi {
   onManualTaskForIdentityFinished(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
-  ): Subscription | Promise<Subscription>;
+  ): Promise<Subscription>;
 }

--- a/typescript/src/apis/index.ts
+++ b/typescript/src/apis/index.ts
@@ -1,5 +1,6 @@
 import * as eventApi from './ievent_consumer_api';
 import * as manualTaskApi from './imanual_task_consumer_api';
+import * as notificationApi from './inotification_consumer_api';
 import * as processModelApi from './iprocess_model_consumer_api';
 import * as userTaskApi from './iuser_task_consumer_api';
 
@@ -7,6 +8,7 @@ import * as userTaskApi from './iuser_task_consumer_api';
 export namespace APIs {
   export import IEventConsumerApi = eventApi.IEventConsumerApi;
   export import IManualTaskConsumerApi = manualTaskApi.IManualTaskConsumerApi;
+  export import INotificationConsumerApi = notificationApi.INotificationConsumerApi;
   export import IProcessModelConsumerApi = processModelApi.IProcessModelConsumerApi;
   export import IUserTaskConsumerApi = userTaskApi.IUserTaskConsumerApi;
 }

--- a/typescript/src/apis/inotification_consumer_api.ts
+++ b/typescript/src/apis/inotification_consumer_api.ts
@@ -2,7 +2,7 @@ import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 /**
- * The INotificationConsumerApi is to manage subscriptions for async notifications.
+ * The INotificationConsumerApi is used to manage subscriptions for async notifications.
  */
 export interface INotificationConsumerApi {
 

--- a/typescript/src/apis/inotification_consumer_api.ts
+++ b/typescript/src/apis/inotification_consumer_api.ts
@@ -1,4 +1,5 @@
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
+import {IIdentity} from '@essential-projects/iam_contracts';
 
 /**
  * The INotificationConsumerApi is to manage subscriptions for async notifications.
@@ -9,7 +10,8 @@ export interface INotificationConsumerApi {
    * Removes the given notification subscription.
    *
    * @async
+   * @param identity     The requesting users identity.
    * @param subscription The subscription to remove.
    */
-  removeSubscription(subscription: Subscription): Promise<void>;
+  removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void>;
 }

--- a/typescript/src/apis/inotification_consumer_api.ts
+++ b/typescript/src/apis/inotification_consumer_api.ts
@@ -1,0 +1,24 @@
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+/**
+ * The INotificationConsumerApi is to manage subscriptions for async notifications.
+ */
+export interface INotificationConsumerApi {
+
+  /**
+   * Removes the given notification subscription.
+   *
+   * @async
+   * @param subscription The subscription to remove.
+   */
+  unsubscribe(subscription: Subscription): Promise<void>;
+
+  /**
+   * Removes all notification subscriptions for the given identity.
+   *
+   * @async
+   * @param identity The identity for which to remove all subscriptions.
+   */
+  unsubscribeAllForIdentity(identity: IIdentity): Promise<void>;
+}

--- a/typescript/src/apis/inotification_consumer_api.ts
+++ b/typescript/src/apis/inotification_consumer_api.ts
@@ -1,5 +1,4 @@
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
-import {IIdentity} from '@essential-projects/iam_contracts';
 
 /**
  * The INotificationConsumerApi is to manage subscriptions for async notifications.
@@ -13,12 +12,4 @@ export interface INotificationConsumerApi {
    * @param subscription The subscription to remove.
    */
   unsubscribe(subscription: Subscription): Promise<void>;
-
-  /**
-   * Removes all notification subscriptions for the given identity.
-   *
-   * @async
-   * @param identity The identity for which to remove all subscriptions.
-   */
-  unsubscribeAllForIdentity(identity: IIdentity): Promise<void>;
 }

--- a/typescript/src/apis/inotification_consumer_api.ts
+++ b/typescript/src/apis/inotification_consumer_api.ts
@@ -11,5 +11,5 @@ export interface INotificationConsumerApi {
    * @async
    * @param subscription The subscription to remove.
    */
-  unsubscribe(subscription: Subscription): Promise<void>;
+  removeSubscription(subscription: Subscription): Promise<void>;
 }

--- a/typescript/src/apis/iprocess_model_consumer_api.ts
+++ b/typescript/src/apis/iprocess_model_consumer_api.ts
@@ -101,14 +101,21 @@ export interface IProcessModelConsumerApi {
    * Executes a callback when a process started.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a new
-   *                   ProcessInstance was started.
-   *                   The message passed to the callback contains further
-   *                   information about the started process.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a new
+   *                        ProcessInstance was started.
+   *                        The message passed to the callback contains further
+   *                        information about the started process.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription>;
+  onProcessStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a new ProcessInstance for a given ProcessModelId
@@ -122,37 +129,55 @@ export interface IProcessModelConsumerApi {
    *                         information about the started ProcessInstance.
    * @param   processModelId The ID of the ProcessModel for which to receive
    *                         notifications.
+   * @param   subscribeOnce  Optional: If set to true, the Subscription will be
+   *                         automatically disposed, after the notification was
+   *                         received once.
    * @returns                The Subscription created by the EventAggregator.
    */
   onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
+    subscribeOnce?: boolean,
   ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ProcessInstance is terminated.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a
-   *                   ProcessInstance is terminated.
-   *                   The message passed to the callback contains further
-   *                   information about the ProcessInstance terminated.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a
+   *                        ProcessInstance is terminated.
+   *                         The message passed to the callback contains further
+   *                         information about the ProcessInstance terminated.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription>;
+  onProcessTerminated(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ProcessInstance ends.
    *
    * @async
-   * @param identity The requesting users identity.
-   * @param callback The callback that will be executed when a
-   *                 ProcessInstance is finished.
-   *                 The message passed to the callback contains further
-   *                 information about the finished ProcessInstance.
-   * @returns        The Subscription created by the EventAggregator.
+   * @param identity        The requesting users identity.
+   * @param callback        The callback that will be executed when a
+   *                        ProcessInstance is finished.
+   *                        The message passed to the callback contains further
+   *                        information about the finished ProcessInstance.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription>;
+  onProcessEnded(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessEndedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 }

--- a/typescript/src/apis/iprocess_model_consumer_api.ts
+++ b/typescript/src/apis/iprocess_model_consumer_api.ts
@@ -1,3 +1,4 @@
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {DataModels} from '../data_models/index';
@@ -100,49 +101,58 @@ export interface IProcessModelConsumerApi {
    * Executes a callback when a process started.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a new
-   *                       ProcessInstance was started.
-   *                       The message passed to the callback contains further
-   *                       information about the started process.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a new
+   *                   ProcessInstance was started.
+   *                   The message passed to the callback contains further
+   *                   information about the started process.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): void;
+  onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Subscription;
 
   /**
    * Executes a callback when a new ProcessInstance for a given ProcessModelId
    * was started.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a new
-   *                       ProcessInstance was started.
-   *                       The message passed to the callback contains further
-   *                       information about the started ProcessInstance.
-   * @param processModelId The ID of the ProcessModel for which to receive notifications.
+   * @param   identity       The requesting users identity.
+   * @param   callback       The callback that will be executed when a new
+   *                         ProcessInstance was started.
+   *                         The message passed to the callback contains further
+   *                         information about the started ProcessInstance.
+   * @param   processModelId The ID of the ProcessModel for which to receive
+   *                         notifications.
+   * @returns                The Subscription created by the EventAggregator.
    */
-  onProcessWithProcessModelIdStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback, processModelId: string): void;
+  onProcessWithProcessModelIdStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    processModelId: string,
+  ): Subscription;
 
   /**
    * Executes a callback when a ProcessInstance is terminated.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a
-   *                       ProcessInstance is terminated.
-   *                       The message passed to the callback contains further
-   *                       information about the ProcessInstance terminated.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a
+   *                   ProcessInstance is terminated.
+   *                   The message passed to the callback contains further
+   *                   information about the ProcessInstance terminated.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void;
+  onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Subscription;
 
   /**
    * Executes a callback when a ProcessInstance ends.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a
-   *                       ProcessInstance is finished.
-   *                       The message passed to the callback contains further
-   *                       information about the finished ProcessInstance.
+   * @param identity The requesting users identity.
+   * @param callback The callback that will be executed when a
+   *                 ProcessInstance is finished.
+   *                 The message passed to the callback contains further
+   *                 information about the finished ProcessInstance.
+   * @returns        The Subscription created by the EventAggregator.
    */
-  onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void;
+  onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Subscription;
 }

--- a/typescript/src/apis/iprocess_model_consumer_api.ts
+++ b/typescript/src/apis/iprocess_model_consumer_api.ts
@@ -108,7 +108,7 @@ export interface IProcessModelConsumerApi {
    *                   information about the started process.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Subscription | Promise<Subscription>;
+  onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription>;
 
   /**
    * Executes a callback when a new ProcessInstance for a given ProcessModelId
@@ -128,7 +128,7 @@ export interface IProcessModelConsumerApi {
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
-  ): Subscription | Promise<Subscription>;
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ProcessInstance is terminated.
@@ -141,7 +141,7 @@ export interface IProcessModelConsumerApi {
    *                   information about the ProcessInstance terminated.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Subscription | Promise<Subscription>;
+  onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription>;
 
   /**
    * Executes a callback when a ProcessInstance ends.
@@ -154,5 +154,5 @@ export interface IProcessModelConsumerApi {
    *                 information about the finished ProcessInstance.
    * @returns        The Subscription created by the EventAggregator.
    */
-  onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Subscription | Promise<Subscription>;
+  onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription>;
 }

--- a/typescript/src/apis/iprocess_model_consumer_api.ts
+++ b/typescript/src/apis/iprocess_model_consumer_api.ts
@@ -108,7 +108,7 @@ export interface IProcessModelConsumerApi {
    *                   information about the started process.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Subscription;
+  onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Subscription | Promise<Subscription>;
 
   /**
    * Executes a callback when a new ProcessInstance for a given ProcessModelId
@@ -128,7 +128,7 @@ export interface IProcessModelConsumerApi {
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
-  ): Subscription;
+  ): Subscription | Promise<Subscription>;
 
   /**
    * Executes a callback when a ProcessInstance is terminated.
@@ -141,7 +141,7 @@ export interface IProcessModelConsumerApi {
    *                   information about the ProcessInstance terminated.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Subscription;
+  onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Subscription | Promise<Subscription>;
 
   /**
    * Executes a callback when a ProcessInstance ends.
@@ -154,5 +154,5 @@ export interface IProcessModelConsumerApi {
    *                 information about the finished ProcessInstance.
    * @returns        The Subscription created by the EventAggregator.
    */
-  onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Subscription;
+  onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Subscription | Promise<Subscription>;
 }

--- a/typescript/src/apis/iuser_task_consumer_api.ts
+++ b/typescript/src/apis/iuser_task_consumer_api.ts
@@ -104,7 +104,7 @@ export interface IUserTaskConsumerApi {
    *                   information about the UserTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Subscription;
+  onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Subscription | Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask is finished.
@@ -117,7 +117,7 @@ export interface IUserTaskConsumerApi {
    *                   information about the UserTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Subscription;
+  onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Subscription | Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask for the given identity is reached.
@@ -130,7 +130,7 @@ export interface IUserTaskConsumerApi {
    *                   information about the UserTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Subscription;
+  onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Subscription | Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask for the given identity is finished.
@@ -143,5 +143,8 @@ export interface IUserTaskConsumerApi {
    *                   information about the UserTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Subscription;
+  onUserTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+  ): Subscription | Promise<Subscription>;
 }

--- a/typescript/src/apis/iuser_task_consumer_api.ts
+++ b/typescript/src/apis/iuser_task_consumer_api.ts
@@ -97,54 +97,79 @@ export interface IUserTaskConsumerApi {
    * Executes a callback when a UserTask is reached.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a UserTask is
-   *                   reached.
-   *                   The message passed to the callback contains further
-   *                   information about the UserTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a UserTask
+   *                        is reached.
+   *                        The message passed to the callback contains further
+   *                        information about the UserTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription>;
+  onUserTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask is finished.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a UserTask is
-   *                   finished.
-   *                   The message passed to the callback contains further
-   *                   information about the UserTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a UserTask
+   *                        is finished.
+   *                        The message passed to the callback contains further
+   *                        information about the UserTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription>;
+  onUserTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask for the given identity is reached.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a UserTask is
-   *                   reached.
-   *                   The message passed to the callback contains further
-   *                   information about the UserTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param identity        The requesting users identity.
+   * @param callback        The callback that will be executed when a UserTask
+   *                        is reached.
+   *                        The message passed to the callback contains further
+   *                        information about the UserTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription>;
+  onUserTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask for the given identity is finished.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a UserTask is
-   *                   finished.
-   *                   The message passed to the callback contains further
-   *                   information about the UserTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a UserTask
+   *                        is finished.
+   *                        The message passed to the callback contains further
+   *                        information about the UserTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
   onUserTaskForIdentityFinished(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce?: boolean,
   ): Promise<Subscription>;
 }

--- a/typescript/src/apis/iuser_task_consumer_api.ts
+++ b/typescript/src/apis/iuser_task_consumer_api.ts
@@ -1,3 +1,4 @@
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {UserTaskList, UserTaskResult} from '../data_models/user_task/index';
@@ -84,53 +85,63 @@ export interface IUserTaskConsumerApi {
    *                           correlation were not found,
    *                           or the user is not authorized to see either.
    */
-  finishUserTask(identity: IIdentity,
-                 processInstanceId: string,
-                 correlationId: string,
-                 userTaskInstanceId: string,
-                 userTaskResult: UserTaskResult): Promise<void>;
+  finishUserTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    userTaskInstanceId: string,
+    userTaskResult: UserTaskResult,
+  ): Promise<void>;
 
   /**
    * Executes a callback when a UserTask is reached.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a UserTask
-   *                       is reached. The message passed to the callback
-   *                       contains further information about the UserTask.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a UserTask is
+   *                   reached.
+   *                   The message passed to the callback contains further
+   *                   information about the UserTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void;
+  onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Subscription;
 
   /**
    * Executes a callback when a UserTask is finished.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a UserTask
-   *                       is finished. The message passed to the callback
-   *                       contains further information about the UserTask.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a UserTask is
+   *                   finished.
+   *                   The message passed to the callback contains further
+   *                   information about the UserTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void;
+  onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Subscription;
 
   /**
    * Executes a callback when a UserTask for the given identity is reached.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a UserTask
-   *                       is reached. The message passed to the callback
-   *                       contains further information about the UserTask.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a UserTask is
+   *                   reached.
+   *                   The message passed to the callback contains further
+   *                   information about the UserTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void;
+  onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Subscription;
 
   /**
    * Executes a callback when a UserTask for the given identity is finished.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a UserTask
-   *                       is finished. The message passed to the callback
-   *                       contains further information about the UserTask.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a UserTask is
+   *                   finished.
+   *                   The message passed to the callback contains further
+   *                   information about the UserTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void;
+  onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Subscription;
 }

--- a/typescript/src/apis/iuser_task_consumer_api.ts
+++ b/typescript/src/apis/iuser_task_consumer_api.ts
@@ -104,7 +104,7 @@ export interface IUserTaskConsumerApi {
    *                   information about the UserTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Subscription | Promise<Subscription>;
+  onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask is finished.
@@ -117,7 +117,7 @@ export interface IUserTaskConsumerApi {
    *                   information about the UserTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Subscription | Promise<Subscription>;
+  onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask for the given identity is reached.
@@ -130,7 +130,7 @@ export interface IUserTaskConsumerApi {
    *                   information about the UserTask.
    * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Subscription | Promise<Subscription>;
+  onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask for the given identity is finished.
@@ -146,5 +146,5 @@ export interface IUserTaskConsumerApi {
   onUserTaskForIdentityFinished(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
-  ): Subscription | Promise<Subscription>;
+  ): Promise<Subscription>;
 }

--- a/typescript/src/iconsumer_api.ts
+++ b/typescript/src/iconsumer_api.ts
@@ -8,5 +8,6 @@ import {APIs} from './apis/index';
 export interface IConsumerApi
   extends APIs.IEventConsumerApi,
           APIs.IManualTaskConsumerApi,
+          APIs.INotificationConsumerApi,
           APIs.IProcessModelConsumerApi,
           APIs.IUserTaskConsumerApi {}

--- a/typescript/src/iconsumer_socket_io_accessor.ts
+++ b/typescript/src/iconsumer_socket_io_accessor.ts
@@ -8,7 +8,6 @@ export interface IConsumerSocketIoAccessor {
   /**
    * Uses the given Identity to connect this client to the Socket.IO server.
    *
-   *
    * @param identity The identity with which to create the connection.
    */
   initializeSocket(identity: IIdentity): void;

--- a/typescript/src/iconsumer_socket_io_accessor.ts
+++ b/typescript/src/iconsumer_socket_io_accessor.ts
@@ -1,0 +1,22 @@
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+/**
+ * Provides functions for managing Socket.IO clients.
+ */
+export interface IConsumerSocketIoAccessor {
+
+  /**
+   * Uses the given Identity to connect this client to the Socket.IO server.
+   *
+   *
+   * @param identity The identity with which to create the connection.
+   */
+  initializeSocket(identity: IIdentity): void;
+
+  /**
+   * Uses the given Identity to disconnect this client from the Socket.IO server.
+   *
+   * @param identity The identity with which to create the connection.
+   */
+  disconnectSocket(identity: IIdentity): void;
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -5,5 +5,6 @@ export * from './messages/index';
 export * from './iconsumer_api_accessor';
 export * from './iconsumer_api_http_controller';
 export * from './iconsumer_api';
+export * from './iconsumer_socket_io_accessor';
 export * from './rest_settings';
 export * from './socket_settings';


### PR DESCRIPTION
**Changes:**

1. Add interface for Socket.IO accessors. Can be used in conjunction with the client's `ExternalAccessor` to make its Socket.IO handling functions accessible to outside components.
2. Make all functions for creating notification subscriptions return the Subscription they created. 
3. Implement the `removeSubscription` UseCase for the ManagementApi and ConsumerApi, which allows a user to unsubscribe from a notification.
4. Implement `subscribeOnce` flag for all notification Subscriptions. This works pretty much like the `subscribeOnce` UseCase for the EventAggregator.


**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/#135
Part of https://github.com/process-engine/process_engine_runtime/issues/#157
Part of https://github.com/process-engine/process_engine_runtime/issues/#206

PR: #55

## How can others test the changes?

Implement the updated contracts.
Your subscription functions will now have to return the subscription they created.
Also, you will be able to provide an optional `subscribeOnce` parameter.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).