### PR TITLE
✨Add missing UseCases to .NET API contracts

### DIFF
--- a/dotnet/src/ProcessEngine.ConsumerAPI.Contracts.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Contracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>12.0.0</Version>
+    <Version>13.0.0</Version>
     <RootNamespace>ProcessEngine.ConsumerAPI.Contracts</RootNamespace>
     <AssemblyName>ProcessEngine.ConsumerAPI.Contracts</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/dotnet/src/RestSettings.cs
+++ b/dotnet/src/RestSettings.cs
@@ -24,7 +24,7 @@ namespace ProcessEngine.ConsumerAPI.Contracts.RestSettings
     {
         public static string ProcessModels { get { return "/process_models"; } }
         public static string ProcessModelById { get { return $"/process_models/{Params.ProcessModelId}"; } }
-        public static string ProcessModelByProcessInstanceId { get { return $"/process_instance/${Params.ProcessInstanceId}/process_model/"; } }
+        public static string ProcessModelByProcessInstanceId { get { return $"/process_instance/{Params.ProcessInstanceId}/process_model/"; } }
         public static string StartProcessInstance { get { return $"/process_models/{Params.ProcessModelId}/start"; } }
         public static string GetOwnProcessInstances { get { return "/process_instances/own"; } }
         public static string GetProcessResultForCorrelation { get { return $"/correlations/{Params.CorrelationId}/process_models/{Params.ProcessModelId}/results"; } }

--- a/dotnet/src/RestSettings.cs
+++ b/dotnet/src/RestSettings.cs
@@ -24,6 +24,7 @@ namespace ProcessEngine.ConsumerAPI.Contracts.RestSettings
     {
         public static string ProcessModels { get { return "/process_models"; } }
         public static string ProcessModelById { get { return $"/process_models/{Params.ProcessModelId}"; } }
+        public static string ProcessModelByProcessInstanceId { get { return $"/process_instance/${Params.ProcessInstanceId}/process_model/"; } }
         public static string StartProcessInstance { get { return $"/process_models/{Params.ProcessModelId}/start"; } }
         public static string GetOwnProcessInstances { get { return "/process_instances/own"; } }
         public static string GetProcessResultForCorrelation { get { return $"/correlations/{Params.CorrelationId}/process_models/{Params.ProcessModelId}/results"; } }

--- a/dotnet/src/apis/IProcessModelConsumerApi.cs
+++ b/dotnet/src/apis/IProcessModelConsumerApi.cs
@@ -2,16 +2,55 @@ namespace ProcessEngine.ConsumerAPI.Contracts.APIs
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using System;
 
     using EssentialProjects.IAM.Contracts;
     using ProcessEngine.ConsumerAPI.Contracts.DataModel;
+    using ProcessEngine.ConsumerAPI.Contracts.Exceptions;
 
     /// <summary>
     /// The IProcessModelConsumerApi is used to retreive ProcessModels and start ProcessInstances.
     /// </summary>
     public interface IProcessModelConsumerApi
     {
+        /// <summary>
+        /// Retrieves a list of all ProcessModels that the requesting user is authorized to see.
+        /// </summary>
+        /// <param name="identity">The requesting users identity.</param>
+        /// <returns>A list of accessible ProcessModels.</returns>
+        /// <exception cref="System.UnauthorizedAccessException">Thrown when the identity has insufficient rights to perform the operation.</exception>
+        /// <exception cref="ProcessNotFoundException"> Thrown when the ProcessModel could not be found.</exception>
+        Task<ProcessModelList> GetProcessModels(IIdentity identity);
+
+        /// <summary>
+        /// Retrieves a ProcessModel by its ID.
+        /// </summary>
+        /// <param name="identity">The requesting users identity.</param>
+        /// <param name="processModelId">The ID of the ProcessModel to retrieve.</param>
+        /// <returns>The retrieved ProcessModel.</returns>
+        /// <exception cref="System.UnauthorizedAccessException">Thrown when the identity has insufficient rights to perform the operation.</exception>
+        /// <exception cref="ProcessNotFoundException"> Thrown when the ProcessModel could not be found.</exception>
+        Task<ProcessModel> GetProcessModelById(IIdentity identity, string processModelId);
+
+        /// <summary>
+        /// Retrieves a ProcessModel by a ProcessInstanceID.
+        /// </summary>
+        /// <param name="identity">The requesting users identity.</param>
+        /// <param name="processInstanceId">The ID of the ProcessInstance for which to retrieve the ProcessModel.</param>
+        /// <returns>The retrieved ProcessModel.</returns>
+        /// <exception cref="System.UnauthorizedAccessException">Thrown when the identity has insufficient rights to perform the operation.</exception>
+        /// <exception cref="ProcessNotFoundException"> Thrown when the ProcessModel could not be found.</exception>
+        Task<ProcessModel> GetProcessModelByProcessInstanceId(IIdentity identity, string processInstanceId);
+
+        /// <summary>
+        /// Gets all active ProcessInstances belonging to the given identity.
+        /// </summary>
+        /// <param name="identity">The identity for which to get the ProcessInstances.</param>
+        /// <returns>The list of ProcessInstances.</returns>
+        /// <exception cref="System.UnauthorizedAccessException">Thrown when the identity has insufficient rights to perform the operation.</exception>
+        /// <exception cref="ProcessNotFoundException"> Thrown when the ProcessModel could not be found.</exception>
+        Task<IEnumerable<ProcessInstance>> GetProcessInstancesByIdentity(IIdentity identity);
+
+
         /// <summary>
         /// Starts an instance for a given ProcessDefinition. Process variables and correlation id may be supplied in the request payload.
         /// </summary>

--- a/dotnet/src/apis/IUserTaskConsumerApi.cs
+++ b/dotnet/src/apis/IUserTaskConsumerApi.cs
@@ -23,7 +23,7 @@ namespace ProcessEngine.ConsumerAPI.Contracts.APIs
         /// <returns>The fetched UserTasks.</returns>
         /// <param name="identity">The requesting users <see cref="EssentialProjects.IAM.Contracts.IIdentity">identity</see>. Should usually contain an auth token.</param>
         /// <param name="processInstanceId">The ID of the ProcessInstance for which to get the UserTasks.</param>
-        Task<UserTaskList> getUserTasksForProcessInstance(IIdentity identity, string processInstanceId);
+        Task<UserTaskList> GetUserTasksForProcessInstance(IIdentity identity, string processInstanceId);
 
         /// <summary>
         /// Retrieves a list of all suspended UserTasks belonging to a specific Correlation.

--- a/dotnet/src/apis/IUserTaskConsumerApi.cs
+++ b/dotnet/src/apis/IUserTaskConsumerApi.cs
@@ -18,6 +18,14 @@ namespace ProcessEngine.ConsumerAPI.Contracts.APIs
         Task<UserTaskList> GetUserTasksForProcessModel(IIdentity identity, string processModelId);
 
         /// <summary>
+        /// Retrieves a list of all suspended UserTasks belonging to the given ProcessInstance.
+        /// </summary>
+        /// <returns>The fetched UserTasks.</returns>
+        /// <param name="identity">The requesting users <see cref="EssentialProjects.IAM.Contracts.IIdentity">identity</see>. Should usually contain an auth token.</param>
+        /// <param name="processInstanceId">The ID of the ProcessInstance for which to get the UserTasks.</param>
+        Task<UserTaskList> getUserTasksForProcessInstance(IIdentity identity, string processInstanceId);
+
+        /// <summary>
         /// Retrieves a list of all suspended UserTasks belonging to a specific Correlation.
         /// </summary>
         /// <returns>The fetched UserTasks.</returns>

--- a/dotnet/src/data_models/ProcessInstance.cs
+++ b/dotnet/src/data_models/ProcessInstance.cs
@@ -15,7 +15,7 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
         /// <summary>
         /// The identity of the ProcessInstance owner.
         /// </summary>
-        public IIdentity Owner { get; set; }
+        public Identity Owner { get; set; }
 
         /// <summary>
         /// The Id of the correlation the ProcessInstance belongs to.

--- a/dotnet/src/data_models/process_model/process_model.cs
+++ b/dotnet/src/data_models/process_model/process_model.cs
@@ -1,0 +1,25 @@
+namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Describes a ProcessModel.
+    /// </summary>
+    public class ProcessModel
+    {
+        /// <summary>
+        /// The ProcessModel's ID.
+        /// </summary>
+        public string ID { get; set; }
+
+        /// <summary>
+        /// A list of accessible StartEvents provided by the ProcessModel.
+        /// </summary>
+        public List<Event> StartEvents { get; set; }
+
+        /// <summary>
+        /// A list of accessible EndEvents provided by the ProcessModel.
+        /// </summary>
+        public List<Event> EndEvents { get; set; }
+    }
+}

--- a/dotnet/src/data_models/process_model/process_model_list.cs
+++ b/dotnet/src/data_models/process_model/process_model_list.cs
@@ -1,0 +1,15 @@
+namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Describes a list of ProcessModels.
+    /// </summary>
+    public class ProcessModelList
+    {
+        /// <summary>
+        /// The ProcessModelList.
+        /// </summary>
+        public IEnumerable<ProcessModel> ProcessModels { get; set; }
+    }
+}


### PR DESCRIPTION
## Changes

Implement some UseCases that were included with the .TS API, but not here.
This mostly includes UseCases for retrieving ProcessModels.

## Issues

PR: #76
