### PR TITLE
♻️ Make ExternalTaskWorker immutable

### DIFF
--- a/dotnet/src/IExternalTaskWorker.cs
+++ b/dotnet/src/IExternalTaskWorker.cs
@@ -7,12 +7,12 @@ namespace ProcessEngine.ConsumerAPI.Contracts
     /// <summary>
     /// Definition of the HandleExternalTask Callback.
     /// </summary>
-    public delegate Task<ExternalTaskResultBase> HandleExternalTaskAction<TPayload>(ExternalTask<TPayload> externalTask);
+    public delegate Task<ExternalTaskResultBase> HandleExternalTaskAction<TPayload, TResult>(ExternalTask<TPayload> externalTask);
 
     /// <summary>
     /// Periodically fetches, locks and processes ExternalTasks for a given topic.
     /// </summary>
-    public interface IExternalTaskWorker<TExternalTaskPayload>
+    public interface IExternalTaskWorker
     {
         /// <summary>
         /// The Id of the worker

--- a/dotnet/src/IExternalTaskWorker.cs
+++ b/dotnet/src/IExternalTaskWorker.cs
@@ -22,11 +22,11 @@ namespace ProcessEngine.ConsumerAPI.Contracts
         /// <summary>
         /// Tells the worker to start polling for ExternalTasks.
         /// </summary>
-        void start();
+        void Start();
 
         /// <summary>
         /// Tells the worker to stop polling for ExternalTasks.
         /// </summary>
-        void stop();
+        void Stop();
     }
 }

--- a/dotnet/src/IExternalTaskWorker.cs
+++ b/dotnet/src/IExternalTaskWorker.cs
@@ -2,7 +2,6 @@ namespace ProcessEngine.ConsumerAPI.Contracts
 {
     using System.Threading.Tasks;
 
-    using EssentialProjects.IAM.Contracts;
     using ProcessEngine.ConsumerAPI.Contracts.DataModel;
 
     /// <summary>
@@ -21,20 +20,13 @@ namespace ProcessEngine.ConsumerAPI.Contracts
         string WorkerId { get; }
 
         /// <summary>
-        /// Periodically fetches, locks and processes available ExternalTasks with a given topic,
-        /// using the given callback as a processing function.
+        /// Tells the worker to start polling for ExternalTasks.
         /// </summary>
-        /// <param name="identity">The identity to use for fetching and processing ExternalTasks.</param>
-        /// <param name="topic">The topic by which to look for and process ExternalTasks.</param>
-        /// <param name="maxTasks">Max. number of ExternalTasks to fetch.</param>
-        /// <param name="longpollingTimeout">Longpolling Timeout in ms.</param>
-        /// <param name="handleAction">The function for processing the ExternalTasks.</param>
-        Task WaitForHandle<TPayload>(
-            IIdentity identity,
-            string topic,
-            int maxTasks,
-            int longpollingTimeout,
-            HandleExternalTaskAction<TPayload> handleAction
-          ) where TPayload : new();
+        void start();
+
+        /// <summary>
+        /// Tells the worker to stop polling for ExternalTasks.
+        /// </summary>
+        void stop();
     }
 }

--- a/dotnet/src/IExternalTaskWorker.cs
+++ b/dotnet/src/IExternalTaskWorker.cs
@@ -12,7 +12,7 @@ namespace ProcessEngine.ConsumerAPI.Contracts
     /// <summary>
     /// Periodically fetches, locks and processes ExternalTasks for a given topic.
     /// </summary>
-    public interface IExternalTaskWorker
+    public interface IExternalTaskWorker<TExternalTaskPayload>
     {
         /// <summary>
         /// The Id of the worker

--- a/typescript/src/data_models/external_task/results/external_task_service_error.ts
+++ b/typescript/src/data_models/external_task/results/external_task_service_error.ts
@@ -4,12 +4,12 @@ import {ExternalTaskResultBase} from './external_task_result_base';
  * Contains the result set for an ExternalTask that failed with a service error.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export class ExternalTaskServiceError<TDetails = any> extends ExternalTaskResultBase {
+export class ExternalTaskServiceError extends ExternalTaskResultBase {
 
   public readonly errorMessage: string;
-  public readonly errorDetails: TDetails;
+  public readonly errorDetails: any;
 
-  constructor(externalTaskId: string, errorMessage: string, errorDetails: TDetails) {
+  constructor(externalTaskId: string, errorMessage: string, errorDetails: any) {
     super(externalTaskId);
     this.errorMessage = errorMessage;
     this.errorDetails = errorDetails;

--- a/typescript/src/data_models/external_task/results/external_task_success_result.ts
+++ b/typescript/src/data_models/external_task/results/external_task_success_result.ts
@@ -3,11 +3,11 @@ import {ExternalTaskResultBase} from './external_task_result_base';
 /**
  * Contains the result set for an ExternalTask that finished successfully.
  */
-export class ExternalTaskSuccessResult<TResult> extends ExternalTaskResultBase {
+export class ExternalTaskSuccessResult extends ExternalTaskResultBase {
 
-  public readonly result: TResult;
+  public readonly result: any;
 
-  constructor(externalTaskId: string, result: TResult) {
+  constructor(externalTaskId: string, result: any) {
     super(externalTaskId);
     this.result = result;
   }

--- a/typescript/src/iexternal_task_worker.ts
+++ b/typescript/src/iexternal_task_worker.ts
@@ -1,5 +1,3 @@
-import {IIdentity} from '@essential-projects/iam_contracts';
-
 import {ExternalTask, ExternalTaskResultBase} from './data_models/external_task/index';
 
 /**
@@ -18,20 +16,12 @@ export interface IExternalTaskWorker {
   workerId: string;
 
   /**
-   * Periodically fetches, locks and processes available ExternalTasks with a given topic,
-   * using the given callback as a processing function.
-   *
-   * @async
-   * @param identity           The identity to use for fetching and processing ExternalTasks.
-   * @param topic              The topic by which to look for and process ExternalTasks.
-   * @param maxTasks           max. ExternalTasks to fetch.
-   * @param longpollingTimeout Longpolling Timeout in ms.
-   * @param handleAction       The function for processing the ExternalTasks.
+   * Tells the worker to start polling for ExternalTasks.
    */
-  waitForAndHandle<TPayload>(
-    identity: IIdentity,
-    topic: string,
-    maxTasks: number,
-    longpollingTimeout: number,
-    handleAction: HandleExternalTaskAction<TPayload>): Promise<void>;
+  start(): void;
+
+  /**
+   * Tells the worker to stop polling for ExternalTasks.
+   */
+  stop(): void;
 }

--- a/typescript/src/iexternal_task_worker.ts
+++ b/typescript/src/iexternal_task_worker.ts
@@ -3,7 +3,7 @@ import {ExternalTask, ExternalTaskResultBase} from './data_models/external_task/
 /**
  * Definition of the HandleExternalTask Callback.
  */
-export type HandleExternalTaskAction<TPayload> = (externalTask: ExternalTask<TPayload>) => Promise<ExternalTaskResultBase>
+export type HandleExternalTaskAction<TPayload, TResult> = (externalTask: ExternalTask<TPayload>) => Promise<ExternalTaskResultBase>
 
 /**
  * Periodically fetches, locks and processes ExternalTasks for a given topic.


### PR DESCRIPTION
## Changes
 
1. Replace `waitForHandle` with `start/stop` pattern
2. Expect all essential parameters to be passed through the constructor
    - This will ensure that a single worker can only process a single topic; as it was meant to be
3. Expect two type parameters for the handler callback: 
    - `TPayload`: The type of the ExternalTask's payload
    - `TResult`: The type of result's payload

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/410

PR: #82