### PR TITLE
🐛 Fix handling of customized ExternalTaskErrors

### DIFF
--- a/dotnet/src/DataModels/ExternalTask/Requests/HandleBpmnErrorRequest.cs
+++ b/dotnet/src/DataModels/ExternalTask/Requests/HandleBpmnErrorRequest.cs
@@ -6,9 +6,17 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
         {
             this.WorkerId = workerId;
             this.ErrorCode = errorCode;
+            this.ErrorMessage = "";
+        }
+        public HandleBpmnErrorRequest(string workerId, string errorCode, string errorMessage)
+        {
+            this.WorkerId = workerId;
+            this.ErrorCode = errorCode;
+            this.ErrorMessage = errorMessage;
         }
 
         public string WorkerId { get; }
         public string ErrorCode { get; }
+        public string ErrorMessage { get; }
     }
 }

--- a/dotnet/src/DataModels/ExternalTask/Requests/HandleServiceErrorRequest.cs
+++ b/dotnet/src/DataModels/ExternalTask/Requests/HandleServiceErrorRequest.cs
@@ -8,8 +8,16 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
             this.ErrorMessage = errorMessage;
             this.ErrorDetails = errorDetails;
         }
+        public HandleServiceErrorRequest(string workerId, string errorMessage, string errorDetails, string errorCode)
+        {
+            this.WorkerId = workerId;
+            this.ErrorCode = errorCode;
+            this.ErrorMessage = errorMessage;
+            this.ErrorDetails = errorDetails;
+        }
 
         public string WorkerId { get; }
+        public string ErrorCode { get; }
         public string ErrorMessage { get; }
         public string ErrorDetails { get; }
     }

--- a/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskBpmnError.cs
+++ b/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskBpmnError.cs
@@ -11,7 +11,7 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
         public ExternalTaskBpmnError(string externalTaskId, string errorCode)
             : base(externalTaskId)
         {
-            this.errorCode = errorCode;
+            this.ErrorCode = errorCode;
         }
         /// <summary></summary>
         /// <param name="externalTaskId"></param>
@@ -20,20 +20,20 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
         public ExternalTaskBpmnError(string externalTaskId, string errorCode, string errorMessage)
             : base(externalTaskId)
         {
-            this.errorCode = errorCode;
-            this.errorMessage = errorMessage;
+            this.ErrorCode = errorCode;
+            this.ErrorMessage = errorMessage;
         }
 
         /// <summary>
         /// The code of the BPMN error that occured.
         /// </summary>
         /// <value></value>
-        public string errorCode { get; private set; }
+        public string ErrorCode { get; private set; }
 
         /// <summary>
         /// The message of the BPMN error that occured.
         /// </summary>
         /// <value></value>
-        public string errorMessage { get; private set; }
+        public string ErrorMessage { get; private set; }
     }
 }

--- a/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskBpmnError.cs
+++ b/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskBpmnError.cs
@@ -13,11 +13,27 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
         {
             this.errorCode = errorCode;
         }
+        /// <summary></summary>
+        /// <param name="externalTaskId"></param>
+        /// <param name="errorCode"></param>
+        /// <param name="errorMessage"></param>
+        public ExternalTaskBpmnError(string externalTaskId, string errorCode, string errorMessage)
+            : base(externalTaskId)
+        {
+            this.errorCode = errorCode;
+            this.errorMessage = errorMessage;
+        }
 
         /// <summary>
         /// The code of the BPMN error that occured.
         /// </summary>
         /// <value></value>
         public string errorCode { get; private set; }
+
+        /// <summary>
+        /// The message of the BPMN error that occured.
+        /// </summary>
+        /// <value></value>
+        public string errorMessage { get; private set; }
     }
 }

--- a/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskResultBase.cs
+++ b/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskResultBase.cs
@@ -9,13 +9,13 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
         /// </summary>
         /// <param name="externalTaskId"></param>
         public ExternalTaskResultBase(string externalTaskId) {
-            this.externalTaskId = externalTaskId;
+            this.ExternalTaskId = externalTaskId;
         }
 
         /// <summary>
         /// The ID of the ExternalTask to which this result belogns.
         /// </summary>
         /// <value></value>
-        public string externalTaskId { get; private set; }
+        public string ExternalTaskId { get; private set; }
     }
 }

--- a/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskServiceError.cs
+++ b/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskServiceError.cs
@@ -12,8 +12,8 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
         public ExternalTaskServiceError(string externalTaskId, string errorMessage, TDetails errorDetails)
             : base(externalTaskId)
         {
-            this.errorMessage = errorMessage;
-            this.errorDetails = errorDetails;
+            this.ErrorMessage = errorMessage;
+            this.ErrorDetails = errorDetails;
         }
 
         /// <summary></summary>
@@ -24,27 +24,27 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
         public ExternalTaskServiceError(string externalTaskId, string errorMessage, string errorCode, TDetails errorDetails)
             : base(externalTaskId)
         {
-            this.errorCode = errorCode;
-            this.errorMessage = errorMessage;
-            this.errorDetails = errorDetails;
+            this.ErrorCode = errorCode;
+            this.ErrorMessage = errorMessage;
+            this.ErrorDetails = errorDetails;
         }
 
         /// <summary>
         /// The mesage of the error that occured.
         /// </summary>
         /// <value></value>
-        public string errorMessage { get; private set; }
+        public string ErrorMessage { get; private set; }
 
         /// <summary>
         /// The code of the error that occured.
         /// </summary>
         /// <value></value>
-        public string errorCode { get; private set; }
+        public string ErrorCode { get; private set; }
 
         /// <summary>
         /// The details provided for this error.
         /// </summary>
         /// <value></value>
-        public TDetails errorDetails { get; private set; }
+        public TDetails ErrorDetails { get; private set; }
     }
 }

--- a/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskServiceError.cs
+++ b/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskServiceError.cs
@@ -16,11 +16,30 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
             this.errorDetails = errorDetails;
         }
 
+        /// <summary></summary>
+        /// <param name="externalTaskId"></param>
+        /// <param name="errorMessage"></param>
+        /// <param name="errorCode"></param>
+        /// <param name="errorDetails"></param>
+        public ExternalTaskServiceError(string externalTaskId, string errorMessage, string errorCode, TDetails errorDetails)
+            : base(externalTaskId)
+        {
+            this.errorCode = errorCode;
+            this.errorMessage = errorMessage;
+            this.errorDetails = errorDetails;
+        }
+
         /// <summary>
         /// The mesage of the error that occured.
         /// </summary>
         /// <value></value>
         public string errorMessage { get; private set; }
+
+        /// <summary>
+        /// The code of the error that occured.
+        /// </summary>
+        /// <value></value>
+        public string errorCode { get; private set; }
 
         /// <summary>
         /// The details provided for this error.

--- a/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskSuccessResult.cs
+++ b/dotnet/src/DataModels/ExternalTask/Results/ExternalTaskSuccessResult.cs
@@ -11,13 +11,13 @@ namespace ProcessEngine.ConsumerAPI.Contracts.DataModel
         public ExternalTaskSuccessResult(string externalTaskId, TResult result)
             :base(externalTaskId)
         {
-            this.result = result;
+            this.Result = result;
         }
 
         /// <summary>
         /// The result with which the ExternalTask has finished.
         /// </summary>
         /// <value></value>
-        public TResult result { get; private set; }
+        public TResult Result { get; private set; }
     }
 }

--- a/dotnet/src/ProcessEngine.ConsumerAPI.Contracts.csproj
+++ b/dotnet/src/ProcessEngine.ConsumerAPI.Contracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>14.2.0</Version>
+    <Version>14.3.0</Version>
     <RootNamespace>ProcessEngine.ConsumerAPI.Contracts</RootNamespace>
     <AssemblyName>ProcessEngine.ConsumerAPI.Contracts</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/dotnet/src/apis/IExternalTaskConsumerApi.cs
+++ b/dotnet/src/apis/IExternalTaskConsumerApi.cs
@@ -47,6 +47,16 @@
         Task HandleBpmnError(IIdentity identity, string workerId, string externalTaskId, string errorCode);
 
         /// <summary>
+        /// Reports a business error in the context of a running external task by ID. The error code must be specified to identify the BPMN error handler.
+        /// </summary>
+        /// <param name="identity">The requesting users identity. Should usually be an auth token.</param>
+        /// <param name="workerId">The ID of the worker that reports the failure. Must match the ID of the worker who has most recently locked the task.</param>
+        /// <param name="externalTaskId">The ID of the external task in which context a BPMN error is reported.</param>
+        /// <param name="errorCode">An error code that indicates the predefined error. Is used to identify the BPMN error handler.</param>
+        /// <param name="errorMessage">A message that describes the error that occured.</param>
+        Task HandleBpmnError(IIdentity identity, string workerId, string externalTaskId, string errorCode, string errorMessage);
+
+        /// <summary>
         /// Reports a failure to execute an external task by ID. A number of retries and a timeout until the task can be retried can be specified. If retries are set to 0, an incident for this task is created.
         /// </summary>
         /// <param name="identity">The requesting users identity. Should usually be an auth token.</param>
@@ -55,6 +65,17 @@
         /// <param name="errorMessage">A message indicating the reason of the failure.</param>
         /// <param name="errorDetails">A detailed error description.</param>
         Task HandleServiceError(IIdentity identity, string workerId, string externalTaskId, string errorMessage, string errorDetails);
+
+        /// <summary>
+        /// Reports a failure to execute an external task by ID. A number of retries and a timeout until the task can be retried can be specified. If retries are set to 0, an incident for this task is created.
+        /// </summary>
+        /// <param name="identity">The requesting users identity. Should usually be an auth token.</param>
+        /// <param name="workerId">The ID of the worker that reports the failure. Must match the ID of the worker who has most recently locked the task.</param>
+        /// <param name="externalTaskId">The ID of the external task to report a failure for.</param>
+        /// <param name="errorMessage">A message indicating the reason of the failure.</param>
+        /// <param name="errorDetails">A detailed error description.</param>
+        /// <param name="errorDetails">A code that describes the error.</param>
+        Task HandleServiceError(IIdentity identity, string workerId, string externalTaskId, string errorMessage, string errorDetails, string errorCode);
 
         /// <summary>
         /// Completes an external task by ID and updates process variables.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_contracts",
-  "version": "9.1.0-alpha.1",
+  "version": "9.2.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/src/apis/iexternal_task_consumer_api.ts
+++ b/typescript/src/apis/iexternal_task_consumer_api.ts
@@ -72,11 +72,18 @@ export interface IExternalTaskConsumerApi {
    *                       error has occured.
    * @param errorCode      An error code that indicates the predefined error.
    *                       This is used to identify the BPMN error handler.
+   * @param errorMessage   Optional: A message to provide with the error.
    * @throws               403, if the requesting User is forbidden to access
    *                       the ExternalTask.
    * @throws               404, if the ExternalTask was not found.
    */
-  handleBpmnError(identity: IIdentity, workerId: string, externalTaskId: string, errorCode: string): Promise<void>;
+  handleBpmnError(
+    identity: IIdentity,
+    workerId: string,
+    externalTaskId: string,
+    errorCode: string,
+    errorMessage?: string,
+  ): Promise<void>;
 
   /**
    *
@@ -90,11 +97,19 @@ export interface IExternalTaskConsumerApi {
    * @param externalTaskId The ID of the ExternalTask to report a failure for.
    * @param errorMessage   A message indicating the reason for the failure.
    * @param errorDetails   A detailed error description.
+   * @param errorMessage   Optional: A code to provide with the error.
    * @throws               403, if the requesting User is forbidden to access
    *                       the ExternalTask.
    * @throws               404, if the ExternalTask was not found.
    */
-  handleServiceError(identity: IIdentity, workerId: string, externalTaskId: string, errorMessage: string, errorDetails: string): Promise<void>;
+  handleServiceError(
+    identity: IIdentity,
+    workerId: string,
+    externalTaskId: string,
+    errorMessage: string,
+    errorDetails: string,
+    errorCode?: string,
+  ): Promise<void>;
 
   /**
    *

--- a/typescript/src/apis/iexternal_task_consumer_api.ts
+++ b/typescript/src/apis/iexternal_task_consumer_api.ts
@@ -34,12 +34,14 @@ export interface IExternalTaskConsumerApi {
    * @throws                     403, if the requesting User is forbidden to
    *                             access ExternalTasks.
    */
-  fetchAndLockExternalTasks<TPayloadType>(identity: IIdentity,
+  fetchAndLockExternalTasks<TPayloadType>(
+    identity: IIdentity,
     workerId: string,
     topicName: string,
     maxTasks: number,
     longPollingTimeout: number,
-    lockDuration: number): Promise<Array<ExternalTask<TPayloadType>>>;
+    lockDuration: number,
+  ): Promise<Array<ExternalTask<TPayloadType>>>;
 
   /**
    *

--- a/typescript/src/data_models/external_task/requests/handle_bpmn_error_request_payload.ts
+++ b/typescript/src/data_models/external_task/requests/handle_bpmn_error_request_payload.ts
@@ -5,10 +5,12 @@ export class HandleBpmnErrorRequestPayload {
 
   public readonly workerId: string;
   public readonly errorCode: string;
+  public readonly errorMessage: string;
 
-  constructor(workerId: string, errorCode: string) {
+  constructor(workerId: string, errorCode: string, errorMessage: string) {
     this.workerId = workerId;
     this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
   }
 
 }

--- a/typescript/src/data_models/external_task/requests/handle_service_error_request_payload.ts
+++ b/typescript/src/data_models/external_task/requests/handle_service_error_request_payload.ts
@@ -6,11 +6,13 @@ export class HandleServiceErrorRequestPayload {
   public readonly workerId: string;
   public readonly errorDetails: string;
   public readonly errorMessage: string;
+  public readonly errorCode: string;
 
-  constructor(workerId: string, errorMessage: string, errorDetails: string) {
+  constructor(workerId: string, errorMessage: string, errorDetails: string, errorCode: string) {
     this.workerId = workerId;
     this.errorMessage = errorMessage;
     this.errorDetails = errorDetails;
+    this.errorCode = errorCode;
   }
 
 }

--- a/typescript/src/data_models/external_task/results/bpmn_error.ts
+++ b/typescript/src/data_models/external_task/results/bpmn_error.ts
@@ -1,0 +1,15 @@
+/**
+ * This type can be used to throw an error modeled at an ErrorEndEvent.
+ */
+export class BpmnError extends Error {
+
+  public readonly code: number | string;
+
+  constructor(name: string, code?: number | string, message?: string) {
+    super(message ?? name);
+    this.name = name;
+    this.code = code ?? '';
+    this.message = message ?? '';
+  }
+
+}

--- a/typescript/src/data_models/external_task/results/bpmn_error.ts
+++ b/typescript/src/data_models/external_task/results/bpmn_error.ts
@@ -1,5 +1,5 @@
 /**
- * This type can be used to throw an error modeled at an ErrorEndEvent.
+ * This type can be used to throw a BPMN error from an ExternalServiceTaskHandler.
  */
 export class BpmnError extends Error {
 

--- a/typescript/src/data_models/external_task/results/bpmn_error.ts
+++ b/typescript/src/data_models/external_task/results/bpmn_error.ts
@@ -1,12 +1,13 @@
 /**
  * This type can be used to throw a BPMN error from an ExternalServiceTaskHandler.
  */
-export class BpmnError extends Error {
+export class BpmnError {
 
+  public readonly name: string;
   public readonly code: number | string;
+  public readonly message: string;
 
   constructor(name: string, code?: number | string, message?: string) {
-    super(message ?? name);
     this.name = name;
     this.code = code ?? '';
     this.message = message ?? '';

--- a/typescript/src/data_models/external_task/results/external_task_bpmn_error.ts
+++ b/typescript/src/data_models/external_task/results/external_task_bpmn_error.ts
@@ -6,10 +6,12 @@ import {ExternalTaskResultBase} from './external_task_result_base';
 export class ExternalTaskBpmnError extends ExternalTaskResultBase {
 
   public readonly errorCode: string;
+  public readonly errorMessage: string;
 
-  constructor(externalTaskId: string, errorCode: string) {
+  constructor(externalTaskId: string, errorCode: string, errorMessage?: string) {
     super(externalTaskId);
     this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
   }
 
 }

--- a/typescript/src/data_models/external_task/results/external_task_service_error.ts
+++ b/typescript/src/data_models/external_task/results/external_task_service_error.ts
@@ -1,18 +1,20 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {ExternalTaskResultBase} from './external_task_result_base';
 
 /**
  * Contains the result set for an ExternalTask that failed with a service error.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class ExternalTaskServiceError extends ExternalTaskResultBase {
 
+  public readonly errorCode: string;
   public readonly errorMessage: string;
   public readonly errorDetails: any;
 
-  constructor(externalTaskId: string, errorMessage: string, errorDetails: any) {
+  constructor(externalTaskId: string, errorMessage: string, errorDetails: any, errorCode?: string) {
     super(externalTaskId);
     this.errorMessage = errorMessage;
     this.errorDetails = errorDetails;
+    this.errorCode = errorCode;
   }
 
 }

--- a/typescript/src/data_models/external_task/results/index.ts
+++ b/typescript/src/data_models/external_task/results/index.ts
@@ -1,3 +1,4 @@
+export * from './bpmn_error';
 export * from './external_task_bpmn_error';
 export * from './external_task_result_base';
 export * from './external_task_service_error';

--- a/typescript/src/data_models/external_task/results/index.ts
+++ b/typescript/src/data_models/external_task/results/index.ts
@@ -3,3 +3,4 @@ export * from './external_task_bpmn_error';
 export * from './external_task_result_base';
 export * from './external_task_service_error';
 export * from './external_task_success_result';
+export * from './service_error';

--- a/typescript/src/data_models/external_task/results/service_error.ts
+++ b/typescript/src/data_models/external_task/results/service_error.ts
@@ -2,13 +2,14 @@
 /**
  * This type can be used to throw a Service error from an ExternalServiceTaskHandler.
  */
-export class ServiceError extends Error {
+export class ServiceError {
 
+  public readonly name: string;
   public readonly code: number | string;
+  public readonly message: string;
   public readonly additionalInformation: any;
 
   constructor(name: string, code?: number | string, message?: string, details?: any) {
-    super(message ?? name);
     this.name = name;
     this.code = code ?? '';
     this.message = message ?? '';

--- a/typescript/src/data_models/external_task/results/service_error.ts
+++ b/typescript/src/data_models/external_task/results/service_error.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * This type can be used to throw a Service error from an ExternalServiceTaskHandler.
+ */
+export class ServiceError extends Error {
+
+  public readonly code: number | string;
+  public readonly additionalInformation: any;
+
+  constructor(name: string, code?: number | string, message?: string, details?: any) {
+    super(message ?? name);
+    this.name = name;
+    this.code = code ?? '';
+    this.message = message ?? '';
+    this.additionalInformation = details;
+  }
+
+}


### PR DESCRIPTION
## Changes (both .NET and .ts)

1. Add `errorMessage` to `ExternalTaskBpmnError` type
2. Add `errorCode` to `ExternalTaskServiceError` type
3. Add optional parameters for each type to the corresponding API functions
4. Add serializable internal types for BpmnError and ServiceError (.ts only)

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/493

PR: #89