### PR TITLE
✨ Add route for retrieving informtion about the host application

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_contracts",
-  "version": "9.3.0",
+  "version": "10.0.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_contracts",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/src/apis/iapplication_info_consumer_api.ts
+++ b/typescript/src/apis/iapplication_info_consumer_api.ts
@@ -1,0 +1,15 @@
+import {ApplicationInfo} from '../data_models/application_info';
+
+/**
+ * The IApplicationInfoConsumerApi is used to retrieve basic information about the running application..
+ */
+export interface IApplicationInfoConsumerApi {
+
+  /**
+   * Gets the package name and version of the running application.
+   *
+   * @async
+   * @returns Some Basic information about the running application.
+   */
+  getApplicationInfo(): Promise<ApplicationInfo>;
+}

--- a/typescript/src/apis/iapplication_info_consumer_api.ts
+++ b/typescript/src/apis/iapplication_info_consumer_api.ts
@@ -1,3 +1,5 @@
+import {IIdentity} from '@essential-projects/iam_contracts';
+
 import {ApplicationInfo} from '../data_models/application_info';
 
 /**
@@ -11,5 +13,5 @@ export interface IApplicationInfoConsumerApi {
    * @async
    * @returns Some Basic information about the running application.
    */
-  getApplicationInfo(): Promise<ApplicationInfo>;
+  getApplicationInfo(identity: IIdentity): Promise<ApplicationInfo>;
 }

--- a/typescript/src/apis/index.ts
+++ b/typescript/src/apis/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import * as appInfoApi from './iapplication_info_consumer_api';
 import * as emptyActivityApi from './iempty_activity_consumer_api';
 import * as eventApi from './ievent_consumer_api';
 import * as externalTaskApi from './iexternal_task_consumer_api';
@@ -9,6 +10,7 @@ import * as userTaskApi from './iuser_task_consumer_api';
 import * as flowNodeInstanceApi from './iflow_node_instance_consumer_api';
 
 export namespace APIs {
+  export import IApplicationInfoConsumerApi = appInfoApi.IApplicationInfoConsumerApi;
   export import IEmptyActivityConsumerApi = emptyActivityApi.IEmptyActivityConsumerApi;
   export import IEventConsumerApi = eventApi.IEventConsumerApi;
   export import IExternalTaskConsumerApi = externalTaskApi.IExternalTaskConsumerApi;

--- a/typescript/src/data_models/application_info.ts
+++ b/typescript/src/data_models/application_info.ts
@@ -1,0 +1,7 @@
+/**
+ * Contains basic information about the running application.
+ */
+export type ApplicationInfo = {
+  name: string;
+  version: string;
+}

--- a/typescript/src/data_models/index.ts
+++ b/typescript/src/data_models/index.ts
@@ -8,9 +8,11 @@ import * as processModels from './process_model/index';
 import * as userTasks from './user_task/index';
 import * as flowNodeInstances from './flow_node_instance/index';
 
+import * as appInfo from './application_info';
 import * as bpmnType from './bpmn_type';
 
 export namespace DataModels {
+  export import ApplicationInfo = appInfo.ApplicationInfo;
   export import BpmnType = bpmnType.BpmnType;
   export import Correlations = correlations;
   export import EmptyActivities = emptyActivities;

--- a/typescript/src/http_controller/iapplication_info_controller.ts
+++ b/typescript/src/http_controller/iapplication_info_controller.ts
@@ -1,0 +1,18 @@
+import {HttpRequestWithIdentity} from '@essential-projects/http_contracts';
+
+import {Response} from 'express';
+
+/**
+ * Describes a HttpController for getting information about the running application.
+ */
+export interface IApplicationInfoController {
+
+  /**
+   * Gets the package name and version of the running application.
+   *
+   * @async
+   * @param request  The HttpRequest object containing all request infos.
+   * @param response The HttpResponse object to use for sending a Http response.
+   */
+  getApplicationInfo(request: HttpRequestWithIdentity, response: Response): Promise<void>;
+}

--- a/typescript/src/http_controller/iapplication_info_controller.ts
+++ b/typescript/src/http_controller/iapplication_info_controller.ts
@@ -3,7 +3,7 @@ import {HttpRequestWithIdentity} from '@essential-projects/http_contracts';
 import {Response} from 'express';
 
 /**
- * Describes a HttpController for getting information about the running application.
+ * Describes an HttpController for getting information about the running application.
  */
 export interface IApplicationInfoController {
 
@@ -12,7 +12,7 @@ export interface IApplicationInfoController {
    *
    * @async
    * @param request  The HttpRequest object containing all request infos.
-   * @param response The HttpResponse object to use for sending a Http response.
+   * @param response The HttpResponse object to use for sending an Http response.
    */
   getApplicationInfo(request: HttpRequestWithIdentity, response: Response): Promise<void>;
 }

--- a/typescript/src/http_controller/index.ts
+++ b/typescript/src/http_controller/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import * as applicationInfoHttpController from './iapplication_info_controller';
 import * as emptyActivityHttpController from './iempty_activity_http_controller';
 import * as eventHttpController from './ievent_http_controller';
 import * as externalTaskHttpController from './iexternal_task_http_controller';
@@ -9,6 +10,7 @@ import * as flowNodeInstanceHttpController from './iflow_node_instance_http_cont
 import * as swaggerHttpController from './iswagger_http_controller';
 
 export namespace HttpController {
+  export import IApplicationInfoHttpController = applicationInfoHttpController.IApplicationInfoController;
   export import IEmptyActivityHttpController = emptyActivityHttpController.IEmptyActivityHttpController;
   export import IEventHttpController = eventHttpController.IEventHttpController;
   export import IExternalTaskHttpController = externalTaskHttpController.IExternalTaskHttpController;

--- a/typescript/src/iconsumer_api_client.ts
+++ b/typescript/src/iconsumer_api_client.ts
@@ -1,6 +1,14 @@
 import {APIs} from './apis/index';
 
 /**
+ * Contains basic information about the running application.
+ */
+export type ApplicationInfo = {
+  name: string;
+  version: string;
+}
+
+/**
  * The client provides endpoints for all UseCases the ConsumerAPI employs.
  */
 export interface IConsumerApiClient
@@ -12,3 +20,10 @@ export interface IConsumerApiClient
   APIs.IProcessModelConsumerApi,
   APIs.IUserTaskConsumerApi,
   APIs.IFlowNodeInstanceConsumerApi {}
+
+/**
+ * The client interface for getting information about the ProcessEngineRuntime.
+ */
+export interface IDomainInfoclient {
+  getApplicationInfo(): Promise<ApplicationInfo>;
+}

--- a/typescript/src/iconsumer_api_client.ts
+++ b/typescript/src/iconsumer_api_client.ts
@@ -1,12 +1,5 @@
 import {APIs} from './apis/index';
-
-/**
- * Contains basic information about the running application.
- */
-export type ApplicationInfo = {
-  name: string;
-  version: string;
-}
+import {ApplicationInfo} from './data_models/application_info';
 
 /**
  * The client provides endpoints for all UseCases the ConsumerAPI employs.

--- a/typescript/src/iconsumer_api_client.ts
+++ b/typescript/src/iconsumer_api_client.ts
@@ -1,11 +1,11 @@
 import {APIs} from './apis/index';
-import {ApplicationInfo} from './data_models/application_info';
 
 /**
  * The client provides endpoints for all UseCases the ConsumerAPI employs.
  */
 export interface IConsumerApiClient
-  extends APIs.IEmptyActivityConsumerApi,
+  extends APIs.IApplicationInfoConsumerApi,
+  APIs.IEmptyActivityConsumerApi,
   APIs.IEventConsumerApi,
   APIs.IExternalTaskConsumerApi,
   APIs.IManualTaskConsumerApi,
@@ -13,10 +13,3 @@ export interface IConsumerApiClient
   APIs.IProcessModelConsumerApi,
   APIs.IUserTaskConsumerApi,
   APIs.IFlowNodeInstanceConsumerApi {}
-
-/**
- * The client interface for getting information about the ProcessEngineRuntime.
- */
-export interface IDomainInfoclient {
-  getApplicationInfo(): Promise<ApplicationInfo>;
-}

--- a/typescript/src/rest_settings.ts
+++ b/typescript/src/rest_settings.ts
@@ -24,6 +24,15 @@ const params = {
 };
 
 const paths = {
+  // Application Info
+
+  /*
+   * Gets some basic info about the application.
+   * @tag AppInfo
+   * @method get
+   */
+  getApplicationInfo: '/info',
+
   // EmptyActivities
 
   /*


### PR DESCRIPTION
## Changes

Add REST settings, API interfaces and data type for `getApplicationInfo` UseCase.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/531

PR: #91